### PR TITLE
Better use of plone z3cform macros

### DIFF
--- a/src/plone/z3cform/crud/crud-master.pt
+++ b/src/plone/z3cform/crud/crud-master.pt
@@ -5,21 +5,21 @@
       i18n:domain="plone.z3cform"
       tal:omit-tag="">
 
-    <tal:status define="status view/status;
-                        has_error python:view.widgets.errors or status == getattr(view, 'formErrorsMessage', None)" condition="status">
-        <dl class="portalMessage error" tal:condition="has_error">
-            <dt i18n:translate="">
-                Error
-            </dt>
-            <dd tal:content="status" />
-        </dl>
-        <dl class="portalMessage info" tal:condition="not:has_error">
-            <dt i18n:translate="">
-                Info
-            </dt>
-            <dd tal:content="status" />
-        </dl>
-    </tal:status>
+  <tal:status define="status view/status;
+                      has_error python:view.widgets.errors or status == getattr(view, 'formErrorsMessage', None)" condition="status">
+      <dl class="portalMessage error" tal:condition="has_error">
+          <dt i18n:translate="">
+              Error
+          </dt>
+          <dd tal:content="status" />
+      </dl>
+      <dl class="portalMessage info" tal:condition="not:has_error">
+          <dt i18n:translate="">
+              Info
+          </dt>
+          <dd tal:content="status" />
+      </dl>
+  </tal:status>
 
   <p class="crud-description discreet"
        tal:condition="view/description"

--- a/src/plone/z3cform/crud/crud-master.pt
+++ b/src/plone/z3cform/crud/crud-master.pt
@@ -5,11 +5,23 @@
       i18n:domain="plone.z3cform"
       tal:omit-tag="">
 
-  <div class="portalMessage"
-       tal:condition="view/status" tal:content="view/status">
-  </div>
+    <tal:status define="status view/status;
+                        has_error python:view.widgets.errors or status == getattr(view, 'formErrorsMessage', None)" condition="status">
+        <dl class="portalMessage error" tal:condition="has_error">
+            <dt i18n:translate="">
+                Error
+            </dt>
+            <dd tal:content="status" />
+        </dl>
+        <dl class="portalMessage info" tal:condition="not:has_error">
+            <dt i18n:translate="">
+                Info
+            </dt>
+            <dd tal:content="status" />
+        </dl>
+    </tal:status>
 
-  <p class="crud-description"
+  <p class="crud-description discreet"
        tal:condition="view/description"
        tal:content="view/description">
   </p>
@@ -19,8 +31,7 @@
        class="crud-form">
   </div>
 
-  <div class="action" tal:repeat="action view/actions/values">
-    <input type="submit" tal:replace="structure action/render" />
-  </div>
+  <metal:block use-macro="context/@@ploneform-macros/fields" />
+  <metal:block use-macro="context/@@ploneform-macros/actions" />
 
 </html>

--- a/src/plone/z3cform/crud/crud-table.pt
+++ b/src/plone/z3cform/crud/crud-table.pt
@@ -8,9 +8,21 @@
   <h2 tal:condition="view/label | nothing"
       tal:content="view/label">Form title</h2>
 
-  <div class="portalMessage"
-       tal:condition="view/status" tal:content="view/status">
-  </div>
+  <tal:status define="status view/status;
+                      has_error python:view.widgets.errors or status == getattr(view, 'formErrorsMessage', None)" condition="status">
+      <dl class="portalMessage error" tal:condition="has_error">
+          <dt i18n:translate="">
+              Error
+          </dt>
+          <dd tal:content="status" />
+      </dl>
+      <dl class="portalMessage info" tal:condition="not:has_error">
+          <dt i18n:translate="">
+              Info
+          </dt>
+          <dd tal:content="status" />
+      </dl>
+  </tal:status>
 
   <form action="." method="post" tal:attributes="action request/getURL">
 
@@ -47,9 +59,8 @@
         </tbody>
     </table>
 
-    <div class="action" tal:repeat="action view/actions/values">
-      <input type="submit" tal:replace="structure action/render" />
-    </div>
+    <metal:block use-macro="context/@@ploneform-macros/fields" />
+    <metal:block use-macro="context/@@ploneform-macros/actions" />
 
   </form>
 


### PR DESCRIPTION
Use default plone z3c form macros for form rendering (harmonized with html and classes)
Also allow the other fields to be displayed on the forms.
